### PR TITLE
Preserve SRID in _tk_OffsetSegment return value

### DIFF
--- a/backend/layoutBoxes.sql
+++ b/backend/layoutBoxes.sql
@@ -54,7 +54,7 @@ BEGIN
     ST_MakePoint(x1, y1)
   );
 
-  return g;
+  return ST_SetSRID(g, ST_SRID(p0));
 END;
 $$
 LANGUAGE 'plpgsql' IMMUTABLE STRICT;


### PR DESCRIPTION
Downstream code using `layoutBoxes` to create geometry started to return "Input geometry has unknown (0) SRID" errors after the switch from `ST_OffsetCurve` to `_tk_OffsetSegment` in 1ef16d75. Assigning the SRID of the first point argument to the return value of `_tk_OffsetSegment` ensures that all generated geometries have the same coordinate system as the block edge input to `layoutBoxes.`

Test select:

``` sql
SELECT ST_AsEWKT(
  _tk_OffsetSegment(
    ST_SetSRID(ST_MakePoint(1029846, 210058), 102718),
    ST_SetSRID(ST_MakePoint(1029847, 210059), 102718),
    2.5
  )
);
```

Before:

``` sql
                                    st_asewkt
---------------------------------------------------------------------------------
 LINESTRING(1029844.23223305 210059.767766953,1029845.23223305 210060.767766953)
```

After:

``` sql
                                          st_asewkt
---------------------------------------------------------------------------------------------
 SRID=102718;LINESTRING(1029844.23223305 210059.767766953,1029845.23223305 210060.767766953)
```
